### PR TITLE
Support agency accounts with per-client settings and full-width header

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -68,6 +68,7 @@ const useAuth = () => {
 
 const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [agency, setAgency] = useState(null);
   const [clients, setClients] = useState([]);
   const [currentClient, setCurrentClient] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -86,6 +87,7 @@ const AuthProvider = ({ children }) => {
     try {
       const response = await axios.get('/auth/me');
       setUser(response.data.user);
+      setAgency(response.data.agency);
       setClients(response.data.clients);
       if (response.data.clients.length > 0) {
         setCurrentClient(response.data.clients[0]);
@@ -98,9 +100,10 @@ const AuthProvider = ({ children }) => {
     }
   };
 
-  const authenticate = (newToken, userData, userClients) => {
+  const authenticate = (newToken, userData, userClients, agencyData) => {
     setToken(newToken);
     setUser(userData);
+    setAgency(agencyData);
     setClients(userClients);
     if (userClients.length > 0) {
       setCurrentClient(userClients[0]);
@@ -113,9 +116,9 @@ const AuthProvider = ({ children }) => {
   const login = async (email, password) => {
     try {
       const response = await axios.post('/auth/login', { email, password });
-      const { token: newToken, user: userData, clients: userClients } = response.data;
+      const { token: newToken, user: userData, clients: userClients, agency: agencyData } = response.data;
 
-      authenticate(newToken, userData, userClients);
+      authenticate(newToken, userData, userClients, agencyData);
 
       toast.success('Succesvol ingelogd!');
       return true;
@@ -128,9 +131,9 @@ const AuthProvider = ({ children }) => {
   const register = async (email, password, name) => {
     try {
       const response = await axios.post('/auth/register', { email, password, name });
-      const { token: newToken, user: userData, client } = response.data;
+      const { token: newToken, user: userData, client, agency: agencyData } = response.data;
 
-      authenticate(newToken, userData, [client]);
+      authenticate(newToken, userData, [client], agencyData);
       setCurrentClient(client);
 
       toast.success('Account succesvol aangemaakt!');
@@ -144,6 +147,7 @@ const AuthProvider = ({ children }) => {
   const logout = () => {
     setToken(null);
     setUser(null);
+    setAgency(null);
     setClients([]);
     setCurrentClient(null);
     localStorage.removeItem('token');
@@ -153,6 +157,7 @@ const AuthProvider = ({ children }) => {
 
   const value = {
     user,
+    agency,
     clients,
     currentClient,
     setCurrentClient,
@@ -1317,8 +1322,8 @@ const Header = () => {
   const { isDark, toggleTheme } = useTheme();
 
   return (
-    <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 w-full">
+      <div className="px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-4">
             <div className="bg-purple-600 w-10 h-10 rounded-xl flex items-center justify-center">
@@ -1410,10 +1415,10 @@ const MainApp = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <Header />
-      <div className="flex">
-        <Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex">
+      <Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
+      <div className="flex-1 flex flex-col">
+        <Header />
         <main className="flex-1 p-8">
           <div className="max-w-7xl mx-auto">
             {renderContent()}

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -15,6 +15,26 @@ const sequelize = new Sequelize(
   }
 );
 
+// Agency Model
+const Agency = sequelize.define('Agency', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  settings: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
+  }
+}, {
+  tableName: 'agencies',
+  timestamps: true
+});
+
 // User Model
 const User = sequelize.define('User', {
   id: {
@@ -48,6 +68,10 @@ const User = sequelize.define('User', {
   },
   lastLogin: {
     type: DataTypes.DATE
+  },
+  agencyId: {
+    type: DataTypes.UUID,
+    allowNull: false
   }
 }, {
   tableName: 'users',
@@ -74,11 +98,16 @@ const Client = sequelize.define('Client', {
     allowNull: false,
     unique: true
   },
+  agencyId: {
+    type: DataTypes.UUID,
+    allowNull: false
+  },
   settings: {
     type: DataTypes.JSONB,
     defaultValue: {
       significanceThreshold: 0.95,
       minimumSampleSize: 1000,
+      goals: [],
       autoStart: false,
       webhookUrl: null
     }
@@ -328,6 +357,12 @@ Invitation.belongsTo(Client, { foreignKey: 'clientId' });
 User.hasMany(Invitation, { foreignKey: 'invitedBy' });
 Invitation.belongsTo(User, { foreignKey: 'invitedBy' });
 
+Agency.hasMany(User, { foreignKey: 'agencyId', onDelete: 'CASCADE' });
+User.belongsTo(Agency, { foreignKey: 'agencyId' });
+
+Agency.hasMany(Client, { foreignKey: 'agencyId', onDelete: 'CASCADE' });
+Client.belongsTo(Agency, { foreignKey: 'agencyId' });
+
 // Export models and sequelize instance
 module.exports = {
   sequelize,
@@ -337,5 +372,6 @@ module.exports = {
   Visitor,
   Conversion,
   UserClient,
-  Invitation
+  Invitation,
+  Agency
 };

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,7 +2,7 @@ const express = require('express');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { body, validationResult } = require('express-validator');
-const { User, Client, UserClient, Invitation } = require('../models');
+const { User, Client, UserClient, Invitation, Agency } = require('../models');
 const { generateApiKey, generateToken } = require('../utils/helpers');
 const { sendEmail, sendInvitationEmail, sendWelcomeEmail } = require('../utils/email');
 const router = express.Router();
@@ -74,19 +74,26 @@ router.post('/register', [
     const saltRounds = 12;
     const hashedPassword = await bcrypt.hash(password, saltRounds);
 
+    // Create agency for user
+    const agency = await Agency.create({
+      name: `${name}'s Agency`
+    });
+
     // Create user
     const user = await User.create({
       email,
       password: hashedPassword,
       name,
-      role: 'admin' // First user is admin
+      role: 'admin', // First user is admin
+      agencyId: agency.id
     });
 
     // Create default client for new user
     const client = await Client.create({
       name: `${name}'s Workspace`,
       domain: 'example.com',
-      apiKey: generateApiKey()
+      apiKey: generateApiKey(),
+      agencyId: agency.id
     });
 
     // Associate user with client
@@ -119,6 +126,11 @@ router.post('/register', [
         name: user.name,
         role: user.role
       },
+      agency: {
+        id: agency.id,
+        name: agency.name,
+        settings: agency.settings
+      },
       client: {
         id: client.id,
         name: client.name,
@@ -145,13 +157,16 @@ router.post('/login', [
     const { email, password } = req.body;
 
     // Find user
-    const user = await User.findOne({ 
+    const user = await User.findOne({
       where: { email },
-      include: [{
-        model: Client,
-        through: UserClient,
-        attributes: ['id', 'name', 'domain']
-      }]
+      include: [
+        { model: Agency, attributes: ['id', 'name', 'settings'] },
+        {
+          model: Client,
+          through: UserClient,
+          attributes: ['id', 'name', 'domain']
+        }
+      ]
     });
 
     if (!user) {
@@ -184,6 +199,7 @@ router.post('/login', [
         role: user.role,
         lastLogin: user.lastLogin
       },
+      agency: user.Agency,
       clients: user.Clients || []
     });
   } catch (error) {
@@ -221,6 +237,7 @@ router.post('/invite', authenticateToken, [
     }
 
     const inviterUser = await User.findByPk(req.user.userId);
+    const frontendUrl = process.env.FRONTEND_URL || req.get('origin') || 'http://localhost:3000';
 
     // Create invitation token
     const token = generateToken(32);
@@ -242,10 +259,12 @@ router.post('/invite', authenticateToken, [
         inviterName: inviterUser?.name || 'Iemand',
         clientName: client.name,
         role,
-        token
+        token,
+        frontendUrl
       });
     } catch (emailError) {
       console.error('Email send failed:', emailError);
+      return res.status(500).json({ error: 'Failed to send invitation email' });
     }
 
     res.json({ message: 'Invitation sent successfully' });
@@ -341,11 +360,14 @@ router.get('/me', authenticateToken, async (req, res) => {
   try {
     const user = await User.findByPk(req.user.userId, {
       attributes: ['id', 'email', 'name', 'role', 'lastLogin'],
-      include: [{
-        model: Client,
-        through: UserClient,
-        attributes: ['id', 'name', 'domain']
-      }]
+      include: [
+        { model: Agency, attributes: ['id', 'name', 'settings'] },
+        {
+          model: Client,
+          through: UserClient,
+          attributes: ['id', 'name', 'domain']
+        }
+      ]
     });
 
     if (!user) {
@@ -360,6 +382,7 @@ router.get('/me', authenticateToken, async (req, res) => {
         role: user.role,
         lastLogin: user.lastLogin
       },
+      agency: user.Agency,
       clients: user.Clients || []
     });
   } catch (error) {

--- a/server/routes/clients.js
+++ b/server/routes/clients.js
@@ -105,11 +105,17 @@ router.post('/', authenticateToken, [
 
     const { name, domain } = req.body;
 
+    const user = await User.findByPk(req.user.userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
     // Create client
     const client = await Client.create({
       name,
       domain,
-      apiKey: generateApiKey()
+      apiKey: generateApiKey(),
+      agencyId: user.agencyId
     });
 
     // Associate user with client as admin

--- a/server/utils/email.js
+++ b/server/utils/email.js
@@ -92,12 +92,13 @@ const sendEmail = async (options) => {
  * @param {string} options.clientName - Name of client/workspace
  * @param {string} options.role - User role
  * @param {string} options.token - Invitation token
+ * @param {string} [options.frontendUrl] - Frontend base URL
  * @returns {Promise} Promise that resolves when email is sent
  */
 const sendInvitationEmail = async (options) => {
-  const { to, inviterName, clientName, role, token } = options;
-  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-  const acceptUrl = `${frontendUrl}/accept-invitation?token=${token}`;
+  const { to, inviterName, clientName, role, token, frontendUrl } = options;
+  const baseUrl = frontendUrl || process.env.FRONTEND_URL || 'http://localhost:3000';
+  const acceptUrl = `${baseUrl}/accept-invitation?token=${token}`;
 
   const subject = `Uitnodiging voor ${clientName} - A/B Testing Platform`;
   


### PR DESCRIPTION
## Summary
- add agency model and connect users/clients with per-client significance and goal settings
- expose agency info in auth flows and attach new clients to an agency
- make header span the full viewport width

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix client -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_6891a34b1ae4832cb43ccfee86640f47