### PR TITLE
refactor: replace global transitions with utility classes

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -29,9 +29,21 @@
   scrollbar-color: #6b7280 #374151;
 }
 
-/* Smooth transitions */
-* {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+/* Transition utilities */
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-opacity {
+  transition-property: opacity;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }


### PR DESCRIPTION
## Summary
- remove global `*` transition styling
- add targeted `.transition-*` utility classes for colors, transform, and opacity

## Testing
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_6899a32daa8c832c9335da3bfae2c87b