### PR TITLE
feat: centralize authentication middleware

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,25 @@
+const supabase = require('../services/supabaseService');
+
+const authenticateToken = async (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({ error: 'Toegangstoken vereist' });
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(403).json({ error: 'Ongeldig of verlopen token' });
+    }
+
+    req.user = data.user; // Contains id and metadata
+    next();
+  } catch (err) {
+    console.error('Authentication error:', err);
+    res.status(500).json({ error: 'Authenticatie mislukt' });
+  }
+};
+
+module.exports = authenticateToken;

--- a/server/routes/analytics.js
+++ b/server/routes/analytics.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { Test, Client, Visitor, Conversion, UserClient } = require('../models');
-const { authenticateToken } = require('./auth');
+const authenticateToken = require('../middleware/auth');
 const router = express.Router();
 
 // Get client dashboard stats
@@ -11,7 +11,7 @@ router.get('/stats/:clientId', authenticateToken, async (req, res) => {
     // Check if user has access to this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId
       }
     });

--- a/server/routes/clients.js
+++ b/server/routes/clients.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const { Client, User, UserClient, Test } = require('../models');
-const { authenticateToken } = require('./auth');
+const authenticateToken = require('../middleware/auth');
 const { generateApiKey } = require('../utils/helpers');
 const router = express.Router();
 
 // Get all clients for authenticated user
 router.get('/', authenticateToken, async (req, res) => {
   try {
-    const user = await User.findByPk(req.user.userId, {
+    const user = await User.findByPk(req.user.id, {
       include: [{
         model: Client,
         through: UserClient,
@@ -48,7 +48,7 @@ router.get('/:id', authenticateToken, async (req, res) => {
     // Check if user has access to this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId: id
       }
     });
@@ -105,7 +105,7 @@ router.post('/', authenticateToken, [
 
     const { name, domain } = req.body;
 
-    const user = await User.findByPk(req.user.userId);
+    const user = await User.findByPk(req.user.id);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
@@ -120,7 +120,7 @@ router.post('/', authenticateToken, [
 
     // Associate user with client as admin
     await UserClient.create({
-      userId: req.user.userId,
+      userId: req.user.id,
       clientId: client.id,
       role: 'admin',
       permissions: {
@@ -167,7 +167,7 @@ router.patch('/:id', authenticateToken, [
     // Check if user has admin access to this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId: id,
         role: 'admin'
       }
@@ -210,7 +210,7 @@ router.patch('/:id/settings', authenticateToken, async (req, res) => {
     // Check if user has admin access to this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId: id,
         role: 'admin'
       }

--- a/server/routes/tests.js
+++ b/server/routes/tests.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { body, validationResult, query } = require('express-validator');
 const { Test, Client, UserClient } = require('../models');
-const { authenticateToken } = require('./auth');
+const authenticateToken = require('../middleware/auth');
 const router = express.Router();
 
 // Get all tests for a client
@@ -16,7 +16,7 @@ router.get('/', authenticateToken, async (req, res) => {
     // Check if user has access to this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId
       }
     });
@@ -58,7 +58,7 @@ router.post('/', authenticateToken, [
     // Check if user has permission to create tests for this client
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId
       }
     });
@@ -96,7 +96,7 @@ router.patch('/:id', authenticateToken, async (req, res) => {
     // Check if user has permission to edit this test
     const userClient = await UserClient.findOne({
       where: {
-        userId: req.user.userId,
+        userId: req.user.id,
         clientId: test.clientId
       }
     });


### PR DESCRIPTION
## Summary
- add reusable Supabase auth middleware that attaches the user object to `req.user`
- refactor routes to use middleware and reference `req.user.id`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6899e97f4660832cab65ee331bb109b0